### PR TITLE
Adjust plugin.zsh file to run on zsh 5.1 in mSYS2.

### DIFF
--- a/slimline.plugin.zsh
+++ b/slimline.plugin.zsh
@@ -1,1 +1,1 @@
-slimline.zsh
+source ${0:A:h}/slimline.zsh


### PR DESCRIPTION
mSYS2 on Windows doesn't support symlinks so I have changed the plugin.zsh to be a normal file for it to work. Probably noone apart of me uses 'slimline' with ZSH on windows but it works and looks great after this one little change.
