### PR TITLE
Added variable SLIMLINE_EXIT_STATUS_SYMBOL to set exit status glyph.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Source the prompt in your `.zshrc` (or other appropriate) file:
 
 Defines the symbol of the prompt. Default is `∙`.
 
+### `SLIMLINE_EXIT_STATUS_SYMBOL`
+
+Defines the symbol of the exit status glyph. Default is `↵`.
+
 ### `SLIMLINE_ENABLE_GIT_RADAR`
 
 Defines whether git-radar shall be used to display git information. Default is `1`.

--- a/slimline.zsh
+++ b/slimline.zsh
@@ -66,7 +66,7 @@ prompt_slimline_set_rprompt() {
 
   # add exit status
   if (( ${SLIMLINE_DISPLAY_EXIT_STATUS:-1} )); then
-    RPROMPT+="%(?::${RPROMPT:+ }%F{red}%? ↵%f)"
+    RPROMPT+="%(?::${RPROMPT:+ }%F{red}%? ${SLIMLINE_EXIT_STATUS_SYMBOL:-↵}%f)"
   fi
 
   # add git radar output


### PR DESCRIPTION
My font of choice "Iosevka" ( https://github.com/be5invis/Iosevka ) doesn't have the default exit status character. It isn't an issue on Linux where my terminal app just fallbacks to another font but on Windows under mintty I just saw an "empty box". This commit adds ability to optionally set SLIMLINE_EXIT_STATUS_SYMBOL to another character (like "Ⓧ").
