### PR TITLE
Add support for python virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ Defines whether active python virtualenv shall be displayed. Default is `1`.
 
 Defines the color of the virtualenv name. Default is `cyan`.
 
+##### `SLIMLINE_VIRTUALENV_PARENS_COLOR`
+
+Defines the color of the parens surrounding the virtualenv name. Default is `white`.
+
 ### Git Information
 
 ##### `SLIMLINE_ENABLE_GIT`

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ For a fish compatible version of this theme have a look at [slimfish](https://gi
     - [User and Host Info](#user-and-host-info)
     - [AWS Profile Info](#aws-profile-info)
     - [Auto Correction](#auto-correction)
+    - [Python Virtualenv](#python-virtualenv)
     - [Git Information](#git-information)
         - [Gitline](#gitline)
 - [Example](#example)

--- a/README.md
+++ b/README.md
@@ -183,6 +183,16 @@ Defines the color of the misspelled string for which is correction is proposed. 
 
 Defines the color of the proposed correction of a misspelled string. Default is `green`.
 
+### Python Virtualenv
+
+##### `SLIMLINE_DISPLAY_VIRTUALENV`
+
+Defines whether active python virtualenv shall be displayed. Default is `1`.
+
+##### `SLIMLINE_VIRTUALENV_COLOR`
+
+Defines the color of the virtualenv name. Default is `cyan`.
+
 ### Git Information
 
 ##### `SLIMLINE_ENABLE_GIT`

--- a/slimline.zsh
+++ b/slimline.zsh
@@ -77,7 +77,7 @@ prompt_slimline_cwd() {
 prompt_slimline_virtualenv() {
   local parens_color='008'
   local virtualenv_color="${SLIMLINE_VIRTUALENV_COLOR:-cyan}"
-  [ $VIRTUAL_ENV ] && echo "%F{parens_color}(%f%F{$virtualenv_color}`basename $VIRTUAL_ENV`%f%F{parens_color})%f"
+  [ $VIRTUAL_ENV ] && echo "%F{$parens_color}(%f%F{$virtualenv_color}`basename $VIRTUAL_ENV`%f%F{$parens_color})%f"
 }
 
 prompt_slimline_set_prompt() {

--- a/slimline.zsh
+++ b/slimline.zsh
@@ -74,6 +74,12 @@ prompt_slimline_cwd() {
   echo "%F{${cwd_color}}%3~%f "
 }
 
+prompt_slimline_virtualenv() {
+  local parens_color='008'
+  local virtualenv_color="${SLIMLINE_VIRTUALENV_COLOR:-cyan}"
+  [ $VIRTUAL_ENV ] && echo "%F{parens_color}(%f%F{$virtualenv_color}`basename $VIRTUAL_ENV`%f%F{parens_color})%f"
+}
+
 prompt_slimline_set_prompt() {
   local symbol_color=${1:-${SLIMLINE_PROMPT_SYMBOL_COLOR_WORKING:-red}}
 
@@ -105,6 +111,11 @@ prompt_slimline_set_rprompt() {
   # add git output
   if [[ -n "${_prompt_slimline_git_output:-}" ]]; then
     RPROMPT+="${RPROMPT:+ }${_prompt_slimline_git_output}"
+  fi
+
+  # add virtualenv (if active)
+  if (( ${SLIMLINE_DISPLAY_VIRTUALENV:-1} )); then
+    RPROMPT+="${RPROMPT:+ }$(prompt_slimline_virtualenv)"
   fi
 }
 

--- a/slimline.zsh
+++ b/slimline.zsh
@@ -113,9 +113,12 @@ prompt_slimline_set_rprompt() {
     RPROMPT+="${RPROMPT:+ }${_prompt_slimline_git_output}"
   fi
 
-  # add virtualenv (if active)
+  # add virtualenv (if active and not empty)
   if (( ${SLIMLINE_DISPLAY_VIRTUALENV:-1} )); then
-    RPROMPT+="${RPROMPT:+ }$(prompt_slimline_virtualenv)"
+    local virtual_env="$(prompt_slimline_virtualenv)"
+    if [[ -n "${virtual_env}" ]]; then
+      RPROMPT+="${RPROMPT:+ }${virtual_env}"
+    fi
   fi
 }
 

--- a/slimline.zsh
+++ b/slimline.zsh
@@ -75,7 +75,7 @@ prompt_slimline_cwd() {
 }
 
 prompt_slimline_virtualenv() {
-  local parens_color='008'
+  local parens_color="${SLIMLINE_VIRTUALENV_PARENS_COLOR:-white}"
   local virtualenv_color="${SLIMLINE_VIRTUALENV_COLOR:-cyan}"
   [ $VIRTUAL_ENV ] && echo "%F{$parens_color}(%f%F{$virtualenv_color}`basename $VIRTUAL_ENV`%f%F{$parens_color})%f"
 }


### PR DESCRIPTION
I added the support for python virtualenv, it is placed to the far right of the prompt, surrounded by parenthesis.

![slimline_venv](https://cloud.githubusercontent.com/assets/971375/26445123/4e2ac468-413f-11e7-8daa-0ab2a6ff2414.png)

I also added a couple of environment variables to enable/disable the feature and change the color.

Let me know if you like this! :smiley: