### PR TITLE
Make default user configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ Defines the color of the user if the user is root. Default is `red`.
 
 Defines the color of the host. Default is `yellow`.
 
+##### `SLIMLINE_DEFAULT_USER`
+
+Username to consider as the default user. By default this is the current effective user (i.e. the output of `whoami`)
+
 ### AWS Profile Info
 
 ##### `SLIMLINE_DISPLAY_AWS_INFO`

--- a/slimline.zsh
+++ b/slimline.zsh
@@ -12,7 +12,7 @@
 #-------------------------------------------------------------------------------
 
 prompt_slimline_path="$(dirname $0:A:H)"
-prompt_slimline_default_user="$(whoami)"
+prompt_slimline_default_user="${SLIMLINE_DEFAULT_USER:-$(whoami)}"
 
 # turns seconds into human readable time
 # 165392 => 1d 21h 56m 32s


### PR DESCRIPTION
By setting SLIMLINE_DEFAULT_USER, you can configure the username to
consider as "default", instead of relying on "whoami".