### PR TITLE
Use _root_ format for all paths outside ~

### DIFF
--- a/sections/cwd.zsh
+++ b/sections/cwd.zsh
@@ -1,6 +1,6 @@
 slimline::section::cwd::render() {
   local -A variables=("path" "%3~")
-  if [[ "$(builtin pwd)" == "/" ]]; then
+  if [[ "$(builtin print -P '%~')" =~ '^/' ]]; then
     slimline::utils::expand "cwd_root" "%F{red}|path|%f" ${(kv)variables}
   else
     slimline::utils::expand "cwd" "%F{cyan}|path|%f" ${(kv)variables}


### PR DESCRIPTION
This PR makes the `cwd` section use `SLIMLINE_CWD_ROOT_FORMAT` for all paths outside the user's home directory, rather than just / as at present.